### PR TITLE
コンテスト問題追加時にフォーカスが動かないようにした & 問題追加中にURLフォームを編集できないようにした

### DIFF
--- a/frontend/src/component/contest/form/ContestTaskFormFields.tsx
+++ b/frontend/src/component/contest/form/ContestTaskFormFields.tsx
@@ -73,12 +73,17 @@ export const ContestTaskFormFields = () => {
         const taskInfo = await fetchTaskInformation(externalTaskId);
 
         if (taskInfo) {
-          append({
-            name: taskInfo.title ?? "",
-            externalTaskId,
-            score: (taskInfo.score ?? 100).toString(),
-            originalScore: (taskInfo.score ?? 0).toString(),
-          });
+          append(
+            {
+              name: taskInfo.title ?? "",
+              externalTaskId,
+              score: (taskInfo.score ?? 100).toString(),
+              originalScore: (taskInfo.score ?? 0).toString(),
+            },
+            {
+              shouldFocus: false,
+            }
+          );
 
           appended = true;
         }
@@ -153,6 +158,7 @@ export const ContestTaskFormFields = () => {
                 e.preventDefault();
               }
             }}
+            disabled={loading}
           />
           <InputRightElement width={16}>
             <Button


### PR DESCRIPTION
- コンテスト問題追加時にフォーカスが動かないようにした (コンテスト追加中に他の入力がしづらくなるため)
- 問題追加中にURLフォームを編集できないようにした (追加終了後に削除されるため)